### PR TITLE
feat: ChainForge bundle deploy integration

### DIFF
--- a/crates/desktop-app/local-server/lib/compose-generator.js
+++ b/crates/desktop-app/local-server/lib/compose-generator.js
@@ -96,7 +96,7 @@ function getAppProfile(programSlug) {
  * @returns {string} docker-compose.yaml content
  */
 function generateComposeFile(opts) {
-  const { programSlug: rawSlug, l1Port, l2Port, proofCoordPort = 3900, metricsPort = 3702, projectName, gpu = false, dumpFixtures = false, isPublic = false, customGenesisPath, l2ChainId, customL1GenesisPath } = opts;
+  const { programSlug: rawSlug, l1Port, l2Port, proofCoordPort = 3900, metricsPort = 3702, projectName, gpu = false, dumpFixtures = false, isPublic = false, customGenesisPath, l2ChainId, customL1GenesisPath, bundleProgramsToml } = opts;
   const programSlug = sanitizeSlug(rawSlug);
   const bindAddr = isPublic ? '0.0.0.0' : '127.0.0.1';
   // Proof coordinator and metrics are internal-only — never bind to 0.0.0.0
@@ -146,21 +146,23 @@ function generateComposeFile(opts) {
   // L2 extra config
   let l2ExtraVolumes = "";
   let l2Genesis = `/genesis/${profile.genesisFile}`;
-  if (profile.programsToml) {
-    l2ExtraVolumes += `      - ${ETHREX_ROOT}/crates/l2/${profile.programsToml}:/etc/ethrex/programs.toml\n`;
+  const programsTomlSource = bundleProgramsToml || (profile.programsToml ? `${ETHREX_ROOT}/crates/l2/${profile.programsToml}` : null);
+  if (programsTomlSource) {
+    l2ExtraVolumes += `      - ${programsTomlSource}:/etc/ethrex/programs.toml\n`;
   }
 
   // Prover config
   let proverExtraEnv = "";
   let proverExtraVolumes = "";
   let proverCommand = `l2 prover --backend ${profile.proverBackend} --proof-coordinators tcp://tokamak-app-l2:3900`;
-  if (profile.proverBackend === "sp1") {
+  if (profile.proverBackend === "sp1" || bundleProgramsToml) {
     proverCommand += ` --programs-config /etc/ethrex/programs.toml`;
     proverExtraEnv = `      - ETHREX_PROGRAMS_CONFIG=/etc/ethrex/programs.toml
       - PROVER_CLIENT_TIMED=true
       - DOCKER_HOST=\${DOCKER_HOST:-unix:///var/run/docker.sock}
       - HOME=\${HOME}`;
-    proverExtraVolumes = `      - ${ETHREX_ROOT}/crates/l2/${profile.programsToml}:/etc/ethrex/programs.toml
+    const proverTomlSource = bundleProgramsToml || `${ETHREX_ROOT}/crates/l2/${profile.programsToml}`;
+    proverExtraVolumes = `      - ${proverTomlSource}:/etc/ethrex/programs.toml
       - /var/run/docker.sock:/var/run/docker.sock
       - \${HOME}/.sp1:\${HOME}/.sp1
       - /tmp:/tmp`;
@@ -840,7 +842,7 @@ function generateTestnetComposeFile(opts) {
     programSlug: rawSlug, l2Port, proofCoordPort = 3900, metricsPort = 3702,
     projectName, l1RpcUrl, gpu = false,
     deployerAddress, committerAddress, proofCoordinatorAddress, bridgeOwnerAddress,
-    isPublic = false, customGenesisPath, l2ChainId,
+    isPublic = false, customGenesisPath, l2ChainId, bundleProgramsToml,
   } = opts;
 
   // Validate required addresses to fail fast on caller errors
@@ -893,20 +895,22 @@ function generateTestnetComposeFile(opts) {
 
   let l2ExtraVolumes = "";
   let l2Genesis = `/genesis/${profile.genesisFile}`;
-  if (profile.programsToml) {
-    l2ExtraVolumes += `      - ${ETHREX_ROOT}/crates/l2/${profile.programsToml}:/etc/ethrex/programs.toml\n`;
+  const testnetTomlSource = bundleProgramsToml || (profile.programsToml ? `${ETHREX_ROOT}/crates/l2/${profile.programsToml}` : null);
+  if (testnetTomlSource) {
+    l2ExtraVolumes += `      - ${testnetTomlSource}:/etc/ethrex/programs.toml\n`;
   }
 
   let proverExtraEnv = "";
   let proverExtraVolumes = "";
   let proverCommand = `l2 prover --backend ${profile.proverBackend} --proof-coordinators tcp://tokamak-app-l2:3900`;
-  if (profile.proverBackend === "sp1") {
+  if (profile.proverBackend === "sp1" || bundleProgramsToml) {
     proverCommand += ` --programs-config /etc/ethrex/programs.toml`;
     proverExtraEnv = `      - ETHREX_PROGRAMS_CONFIG=/etc/ethrex/programs.toml
       - PROVER_CLIENT_TIMED=true
       - DOCKER_HOST=\${DOCKER_HOST:-unix:///var/run/docker.sock}
       - HOME=\${HOME}`;
-    proverExtraVolumes = `      - ${ETHREX_ROOT}/crates/l2/${profile.programsToml}:/etc/ethrex/programs.toml
+    const testnetProverToml = bundleProgramsToml || `${ETHREX_ROOT}/crates/l2/${profile.programsToml}`;
+    proverExtraVolumes = `      - ${testnetProverToml}:/etc/ethrex/programs.toml
       - /var/run/docker.sock:/var/run/docker.sock
       - \${HOME}/.sp1:\${HOME}/.sp1
       - /tmp:/tmp`;

--- a/crates/desktop-app/local-server/lib/compose-generator.js
+++ b/crates/desktop-app/local-server/lib/compose-generator.js
@@ -155,15 +155,16 @@ function generateComposeFile(opts) {
   let proverExtraEnv = "";
   let proverExtraVolumes = "";
   let proverCommand = `l2 prover --backend ${profile.proverBackend} --proof-coordinators tcp://tokamak-app-l2:3900`;
-  if (profile.proverBackend === "sp1" || bundleProgramsToml) {
+  if (programsTomlSource) {
     proverCommand += ` --programs-config /etc/ethrex/programs.toml`;
-    proverExtraEnv = `      - ETHREX_PROGRAMS_CONFIG=/etc/ethrex/programs.toml
-      - PROVER_CLIENT_TIMED=true
+    proverExtraEnv = `      - ETHREX_PROGRAMS_CONFIG=/etc/ethrex/programs.toml`;
+    proverExtraVolumes = `      - ${programsTomlSource}:/etc/ethrex/programs.toml`;
+  }
+  if (profile.proverBackend === "sp1") {
+    proverExtraEnv += (proverExtraEnv ? "\n" : "") + `      - PROVER_CLIENT_TIMED=true
       - DOCKER_HOST=\${DOCKER_HOST:-unix:///var/run/docker.sock}
       - HOME=\${HOME}`;
-    const proverTomlSource = bundleProgramsToml || `${ETHREX_ROOT}/crates/l2/${profile.programsToml}`;
-    proverExtraVolumes = `      - ${proverTomlSource}:/etc/ethrex/programs.toml
-      - /var/run/docker.sock:/var/run/docker.sock
+    proverExtraVolumes += (proverExtraVolumes ? "\n" : "") + `      - /var/run/docker.sock:/var/run/docker.sock
       - \${HOME}/.sp1:\${HOME}/.sp1
       - /tmp:/tmp`;
   }
@@ -903,15 +904,16 @@ function generateTestnetComposeFile(opts) {
   let proverExtraEnv = "";
   let proverExtraVolumes = "";
   let proverCommand = `l2 prover --backend ${profile.proverBackend} --proof-coordinators tcp://tokamak-app-l2:3900`;
-  if (profile.proverBackend === "sp1" || bundleProgramsToml) {
+  if (testnetTomlSource) {
     proverCommand += ` --programs-config /etc/ethrex/programs.toml`;
-    proverExtraEnv = `      - ETHREX_PROGRAMS_CONFIG=/etc/ethrex/programs.toml
-      - PROVER_CLIENT_TIMED=true
+    proverExtraEnv = `      - ETHREX_PROGRAMS_CONFIG=/etc/ethrex/programs.toml`;
+    proverExtraVolumes = `      - ${testnetTomlSource}:/etc/ethrex/programs.toml`;
+  }
+  if (profile.proverBackend === "sp1") {
+    proverExtraEnv += (proverExtraEnv ? "\n" : "") + `      - PROVER_CLIENT_TIMED=true
       - DOCKER_HOST=\${DOCKER_HOST:-unix:///var/run/docker.sock}
       - HOME=\${HOME}`;
-    const testnetProverToml = bundleProgramsToml || `${ETHREX_ROOT}/crates/l2/${profile.programsToml}`;
-    proverExtraVolumes = `      - ${testnetProverToml}:/etc/ethrex/programs.toml
-      - /var/run/docker.sock:/var/run/docker.sock
+    proverExtraVolumes += (proverExtraVolumes ? "\n" : "") + `      - /var/run/docker.sock:/var/run/docker.sock
       - \${HOME}/.sp1:\${HOME}/.sp1
       - /tmp:/tmp`;
   }

--- a/crates/desktop-app/local-server/lib/deployment-engine.js
+++ b/crates/desktop-app/local-server/lib/deployment-engine.js
@@ -88,6 +88,21 @@ const deploymentEvents = new Map();
 // Active provision registry -- tracks which deployments have a running provision()
 const activeProvisions = new Map(); // id -> { startedAt, phase, abortController }
 
+/**
+ * Resolve ChainForge bundle programs.toml path if present.
+ * Returns the absolute path to programs.toml, or null if not a bundle or file doesn't exist.
+ */
+function findBundleProgramsToml(isBundle, deployDir, id, emit) {
+  if (!isBundle) return null;
+  const resolvedDir = deployDir || getDeploymentDir(id);
+  const tomlPath = path.join(resolvedDir, "programs.toml");
+  if (fs.existsSync(tomlPath)) {
+    if (emit) emit(id, "log", { message: `Using ChainForge bundle programs.toml: ${tomlPath}` });
+    return tomlPath;
+  }
+  return null;
+}
+
 const PHASES = [
   "configured",
   "checking_docker",
@@ -476,15 +491,7 @@ async function provision(deployment) {
     forceRebuild = !!config.forceRebuild;
     forceRedeploy = !!config.forceRedeploy;
     isBundle = !!config.chainforgeBundle;
-    // Check for ChainForge bundle programs.toml (same config parse)
-    if (isBundle) {
-      const resolvedDir = deployDir || getDeploymentDir(id);
-      const bundleTomlPath = path.join(resolvedDir, "programs.toml");
-      if (fs.existsSync(bundleTomlPath)) {
-        bundleProgramsToml = bundleTomlPath;
-        emit(id, "log", { message: `Using ChainForge bundle programs.toml: ${bundleTomlPath}` });
-      }
-    }
+    bundleProgramsToml = findBundleProgramsToml(isBundle, deployDir, id, emit);
   } catch (e) { console.warn("[deploy] Failed to check bundle programs.toml:", e.message); }
 
   const { l1Port, l2Port, proofCoordPort, toolsL1ExplorerPort, toolsL2ExplorerPort, toolsBridgeUIPort, toolsDbPort, toolsMetricsPort } = await getNextAvailablePorts();
@@ -1179,15 +1186,7 @@ async function provisionTestnet(deployment) {
   const { customGenesisPath, l2ChainId } = await ensureChainIds(deployment, deployDir, { isBundle });
 
   // Check for ChainForge bundle programs.toml
-  let bundleProgramsToml = null;
-  if (isBundle) {
-    const testnetResolvedDir = deployDir || getDeploymentDir(id);
-    const testnetBundleTomlPath = path.join(testnetResolvedDir, "programs.toml");
-    if (fs.existsSync(testnetBundleTomlPath)) {
-      bundleProgramsToml = testnetBundleTomlPath;
-      emit(id, "log", { message: `Using ChainForge bundle programs.toml: ${testnetBundleTomlPath}` });
-    }
-  }
+  const bundleProgramsToml = findBundleProgramsToml(isBundle, deployDir, id, emit);
 
   let composeFile = null;
   const contractLogLines = []; // Track deployer logs for address recovery on cancel

--- a/crates/desktop-app/local-server/lib/deployment-engine.js
+++ b/crates/desktop-app/local-server/lib/deployment-engine.js
@@ -381,7 +381,7 @@ function getActiveProvisions() {
  * Ensure the deployment has a unique L2 chain ID and write a
  * deployment-specific genesis file with that chain ID.
  */
-async function ensureChainIds(deployment, deployDir, { includeL1 = false } = {}) {
+async function ensureChainIds(deployment, deployDir, { includeL1 = false, isBundle = false } = {}) {
   const { id, program_slug: programSlug } = deployment;
 
   // L2 Chain ID
@@ -390,7 +390,26 @@ async function ensureChainIds(deployment, deployDir, { includeL1 = false } = {})
     l2ChainId = getNextAvailableL2ChainId();
     updateDeployment(id, { chain_id: l2ChainId });
   }
-  const customGenesisPath = await writeCustomGenesis(programSlug, l2ChainId, id, deployDir);
+
+  let customGenesisPath;
+  const resolvedDeployDir = deployDir || getDeploymentDir(id);
+  const bundleGenesisPath = path.join(resolvedDeployDir, "l2.json");
+
+  if (isBundle && fs.existsSync(bundleGenesisPath)) {
+    // ChainForge bundle: genesis already written by from-bundle endpoint
+    // Update chainId in the existing genesis to match deployment's chain ID
+    try {
+      const genesis = JSON.parse(fs.readFileSync(bundleGenesisPath, "utf-8"));
+      genesis.config.chainId = l2ChainId;
+      fs.writeFileSync(bundleGenesisPath, JSON.stringify(genesis, null, 2), "utf-8");
+    } catch (e) {
+      emit(id, "log", { message: `Warning: could not update chainId in bundle genesis: ${e.message}` });
+    }
+    customGenesisPath = bundleGenesisPath;
+    emit(id, "log", { message: `Using ChainForge bundle genesis: ${bundleGenesisPath}` });
+  } else {
+    customGenesisPath = await writeCustomGenesis(programSlug, l2ChainId, id, deployDir);
+  }
   emit(id, "log", { message: `L2 Chain ID: ${l2ChainId}` });
 
   // L1 Chain ID (local deployments only — each gets its own L1 node)
@@ -448,13 +467,25 @@ async function provision(deployment) {
   let dumpFixtures = false;
   let forceRebuild = false;
   let forceRedeploy = false;
+  let bundleProgramsToml = null;
+  let isBundle = false;
   try {
     const config = deployment.config ? JSON.parse(deployment.config) : {};
     deployDir = config.deployDir || null;
     dumpFixtures = !!config.dumpFixtures;
     forceRebuild = !!config.forceRebuild;
     forceRedeploy = !!config.forceRedeploy;
-  } catch {}
+    isBundle = !!config.chainforgeBundle;
+    // Check for ChainForge bundle programs.toml (same config parse)
+    if (isBundle) {
+      const resolvedDir = deployDir || getDeploymentDir(id);
+      const bundleTomlPath = path.join(resolvedDir, "programs.toml");
+      if (fs.existsSync(bundleTomlPath)) {
+        bundleProgramsToml = bundleTomlPath;
+        emit(id, "log", { message: `Using ChainForge bundle programs.toml: ${bundleTomlPath}` });
+      }
+    }
+  } catch (e) { console.warn("[deploy] Failed to check bundle programs.toml:", e.message); }
 
   const { l1Port, l2Port, proofCoordPort, toolsL1ExplorerPort, toolsL2ExplorerPort, toolsBridgeUIPort, toolsDbPort, toolsMetricsPort } = await getNextAvailablePorts();
   const projectName = `tokamak-${id.slice(0, 8)}`;
@@ -477,12 +508,12 @@ async function provision(deployment) {
   provisionInfo.phase = "building";
   emit(id, "phase", { phase: "building", message: "Generating Docker Compose configuration..." });
 
-  const { customGenesisPath, l2ChainId, customL1GenesisPath } = await ensureChainIds(deployment, deployDir, { includeL1: true });
+  const { customGenesisPath, l2ChainId, customL1GenesisPath } = await ensureChainIds(deployment, deployDir, { includeL1: true, isBundle });
 
   let composeFile = null;
   try {
     const gpu = docker.hasNvidiaGpu();
-    const composeContent = generateComposeFile({ programSlug, l1Port, l2Port, proofCoordPort, metricsPort: toolsMetricsPort, projectName, gpu, dumpFixtures, customGenesisPath, l2ChainId, customL1GenesisPath });
+    const composeContent = generateComposeFile({ programSlug, l1Port, l2Port, proofCoordPort, metricsPort: toolsMetricsPort, projectName, gpu, dumpFixtures, customGenesisPath, l2ChainId, customL1GenesisPath, bundleProgramsToml });
     composeFile = writeComposeFile(id, composeContent, deployDir);
 
     // Check for existing images to skip rebuild (unless forceRebuild)
@@ -1054,11 +1085,24 @@ async function provisionTestnet(deployment) {
 
   let deployDir = null;
   let testnetConfig = {};
+  let isBundle = false;
   try {
     const config = deployment.config ? JSON.parse(deployment.config) : {};
     deployDir = config.deployDir || null;
-    testnetConfig = config.testnet || {};
-  } catch {}
+    isBundle = !!config.chainforgeBundle;
+    if (isBundle) {
+      // ChainForge bundle stores testnet config at top level
+      testnetConfig = {
+        l1RpcUrl: config.l1RpcUrl,
+        keychainKeyName: config.deployerKey,
+        committerKeychainKey: config.committerKey,
+        proofCoordinatorKeychainKey: config.proofCoordinatorKey,
+        bridgeOwnerKeychainKey: config.bridgeOwnerKey,
+      };
+    } else {
+      testnetConfig = config.testnet || {};
+    }
+  } catch (e) { console.warn("[deploy] Failed to parse testnet config:", e.message); }
 
   const l1RpcUrl = testnetConfig.l1RpcUrl;
   if (!l1RpcUrl) {
@@ -1132,7 +1176,18 @@ async function provisionTestnet(deployment) {
   provisionInfo.phase = "building";
   emit(id, "phase", { phase: "building", message: "Generating Docker Compose configuration (testnet mode)..." });
 
-  const { customGenesisPath, l2ChainId } = await ensureChainIds(deployment, deployDir);
+  const { customGenesisPath, l2ChainId } = await ensureChainIds(deployment, deployDir, { isBundle });
+
+  // Check for ChainForge bundle programs.toml
+  let bundleProgramsToml = null;
+  if (isBundle) {
+    const testnetResolvedDir = deployDir || getDeploymentDir(id);
+    const testnetBundleTomlPath = path.join(testnetResolvedDir, "programs.toml");
+    if (fs.existsSync(testnetBundleTomlPath)) {
+      bundleProgramsToml = testnetBundleTomlPath;
+      emit(id, "log", { message: `Using ChainForge bundle programs.toml: ${testnetBundleTomlPath}` });
+    }
+  }
 
   let composeFile = null;
   const contractLogLines = []; // Track deployer logs for address recovery on cancel
@@ -1155,7 +1210,7 @@ async function provisionTestnet(deployment) {
       programSlug, l2Port, proofCoordPort, metricsPort: toolsMetricsPort,
       projectName, l1RpcUrl, gpu,
       ...addresses,
-      customGenesisPath, l2ChainId,
+      customGenesisPath, l2ChainId, bundleProgramsToml,
     });
     composeFile = writeComposeFile(id, composeContent, deployDir);
 

--- a/crates/desktop-app/local-server/public/app.js
+++ b/crates/desktop-app/local-server/public/app.js
@@ -4910,7 +4910,7 @@ async function loadBundleKeychainKeys() {
       if (!sel) return;
       const currentVal = sel.value;
       const defaultLabel = i === 0 ? 'Select key...' : 'Same as Deployer';
-      sel.innerHTML = `<option value="">${defaultLabel}</option>` + keys.map(k => `<option value="${k}">${k}</option>`).join('');
+      sel.innerHTML = `<option value="">${defaultLabel}</option>` + keys.map(k => `<option value="${esc(k)}">${esc(k)}</option>`).join('');
       if (currentVal) sel.value = currentVal;
     });
   } catch (e) { console.warn('[bundle] Failed to load keychain keys:', e.message); }

--- a/crates/desktop-app/local-server/public/app.js
+++ b/crates/desktop-app/local-server/public/app.js
@@ -46,7 +46,7 @@ let elapsedInterval = null;
 // ============================================================
 // Navigation
 // ============================================================
-const pageTitles = { deployments: 'My L2s', launch: 'Launch L2', hosts: 'Remote Hosts', detail: 'L2 Details', 'guest-builds': 'Guest Builds' };
+const pageTitles = { deployments: 'My L2s', launch: 'Launch L2', hosts: 'Remote Hosts', detail: 'L2 Details', 'guest-builds': 'Guest Builds', 'bundle-deploy': 'Deploy ChainForge Bundle' };
 
 document.querySelectorAll('.nav-link').forEach(btn => {
   btn.addEventListener('click', () => showView(btn.dataset.view));
@@ -4793,7 +4793,7 @@ async function showBuildDetail(buildId) {
             <div style="font-size:12px;font-weight:700;color:#a1a1aa;">Build Logs</div>
             <span style="font-size:10px;color:#52525b;">${logs.length} lines</span>
           </div>
-          <div style="background:#000;border-radius:8px;padding:12px;max-height:280px;overflow-y:auto;font-family:monospace;font-size:10px;line-height:1.6;">
+          <div style="background:#000;border-radius:10px;padding:20px 24px;max-height:360px;overflow-y:auto;font-family:monospace;font-size:11px;line-height:2.0;">
             ${logs.length === 0
               ? '<span style="color:#52525b;">No logs available</span>'
               : logs.map(line => {
@@ -4846,10 +4846,247 @@ async function showBuildDetail(buildId) {
   }
 }
 
+// ============================================================
+// Bundle Deploy (ChainForge)
+// ============================================================
+let bundleDeploymentId = null;
+let bundleMode = 'local';
+
+function showBundleDeploy(deploymentId) {
+  bundleDeploymentId = deploymentId;
+  bundleMode = 'local';
+  showView('bundle-deploy');
+
+  // Load deployment info
+  fetch(`${API}/deployments/${deploymentId}`).then(r => r.json()).then(data => {
+    const dep = data.deployment;
+    if (!dep) return;
+
+    document.getElementById('bundle-chain-name').textContent = dep.name;
+    document.getElementById('bundle-chain-id').textContent = dep.chain_id || 'auto';
+
+    let config = {};
+    try { config = dep.config ? JSON.parse(dep.config) : {}; } catch (e) { console.warn('[bundle] config parse:', e.message); }
+
+    const programs = config.bundlePrograms || [];
+    document.getElementById('bundle-program-count').textContent = programs.length;
+
+    const listEl = document.getElementById('bundle-program-list');
+    if (programs.length > 0) {
+      listEl.innerHTML = '';
+      programs.forEach(p => {
+        const span = document.createElement('span');
+        span.style.cssText = 'display:inline-block;background:var(--bg-surface,#1a1a2e);border:1px solid var(--border,#333);border-radius:4px;padding:2px 8px;margin:2px 4px 2px 0;font-size:10px';
+        span.textContent = `${p.programId || p.displayName || 'unknown'} (${p.role || 'app'})`;
+        listEl.appendChild(span);
+      });
+    } else {
+      listEl.textContent = '';
+    }
+  });
+
+  // Reset mode UI
+  setBundleMode('local');
+  loadBundleKeychainKeys();
+}
+
+function setBundleMode(mode) {
+  bundleMode = mode;
+  document.querySelectorAll('#view-bundle-deploy .mode-card').forEach(c => {
+    c.classList.toggle('active', c.dataset.mode === mode);
+  });
+  const testnetFields = document.getElementById('bundle-testnet-fields');
+  if (testnetFields) testnetFields.style.display = mode === 'testnet' ? '' : 'none';
+}
+
+async function loadBundleKeychainKeys() {
+  try {
+    const res = await fetch(`${API}/keychain/keys`);
+    const data = await res.json();
+    const keys = data.keys || [];
+    const selectors = ['bundle-deployer-key', 'bundle-committer-key', 'bundle-proof-coordinator-key', 'bundle-bridge-owner-key'];
+    selectors.forEach((selId, i) => {
+      const sel = document.getElementById(selId);
+      if (!sel) return;
+      const currentVal = sel.value;
+      const defaultLabel = i === 0 ? 'Select key...' : 'Same as Deployer';
+      sel.innerHTML = `<option value="">${defaultLabel}</option>` + keys.map(k => `<option value="${k}">${k}</option>`).join('');
+      if (currentVal) sel.value = currentVal;
+    });
+  } catch (e) { console.warn('[bundle] Failed to load keychain keys:', e.message); }
+}
+
+function refreshBundleKeychainKeys() {
+  loadBundleKeychainKeys();
+}
+
+async function onBundleKeychainKeyChange() {
+  const sel = document.getElementById('bundle-deployer-key');
+  if (!sel || !sel.value) {
+    document.getElementById('bundle-deployer-addr').value = '';
+    return;
+  }
+  try {
+    const res = await fetch(`${API}/keychain/keys/${encodeURIComponent(sel.value)}`);
+    const data = await res.json();
+    if (data.address) {
+      document.getElementById('bundle-deployer-addr').value = data.address;
+      // Update role defaults
+      ['committer', 'proof-coordinator', 'bridge-owner'].forEach(role => {
+        const roleSel = document.getElementById(`bundle-${role}-key`);
+        const roleAddr = document.getElementById(`bundle-${role}-addr`);
+        if (roleSel && !roleSel.value && roleAddr) {
+          roleAddr.value = data.address;
+          roleAddr.style.color = '#9ca3af';
+        }
+      });
+    }
+  } catch (e) { console.warn('[bundle] keychain key change:', e.message); }
+}
+
+async function onBundleRoleKeyChange(role) {
+  const sel = document.getElementById(`bundle-${role}-key`);
+  const addrEl = document.getElementById(`bundle-${role}-addr`);
+  if (!sel || !addrEl) return;
+
+  if (!sel.value) {
+    const deployerAddr = document.getElementById('bundle-deployer-addr')?.value || '';
+    addrEl.value = deployerAddr || '= Deployer';
+    addrEl.style.color = '#9ca3af';
+    return;
+  }
+  try {
+    const res = await fetch(`${API}/keychain/keys/${encodeURIComponent(sel.value)}`);
+    const data = await res.json();
+    if (data.address) {
+      addrEl.value = data.address;
+      addrEl.style.color = '#4b5563';
+    }
+  } catch (e) { console.warn(`[bundle] role key change (${role}):`, e.message); }
+}
+
+async function checkBundleTestnetBalance() {
+  const rpcUrl = document.getElementById('bundle-testnet-rpc')?.value;
+  const deployerAddr = document.getElementById('bundle-deployer-addr')?.value;
+  if (!rpcUrl || !deployerAddr) {
+    document.getElementById('bundle-balance-check').innerHTML = '<span style="color:#f87171;font-size:11px">Please set RPC URL and deployer key first.</span>';
+    return;
+  }
+
+  const roles = [
+    { role: 'deployer', address: deployerAddr, statusId: 'bundle-balance-deployer' },
+    { role: 'committer', address: document.getElementById('bundle-committer-addr')?.value || deployerAddr, statusId: 'bundle-balance-committer' },
+    { role: 'proof-coordinator', address: document.getElementById('bundle-proof-coordinator-addr')?.value || deployerAddr, statusId: 'bundle-balance-proof-coordinator' },
+    { role: 'bridge-owner', address: document.getElementById('bundle-bridge-owner-addr')?.value || deployerAddr, statusId: 'bundle-balance-bridge-owner' },
+  ];
+
+  for (const { role, address, statusId } of roles) {
+    const statusEl = document.getElementById(statusId);
+    if (!statusEl) continue;
+    if (!address || address === '= Deployer') { statusEl.innerHTML = ''; continue; }
+    statusEl.innerHTML = '<span style="font-size:10px;color:#888">Checking...</span>';
+    try {
+      const res = await fetch(`${API}/deployments/testnet/check-balance`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ rpcUrl, address, role }),
+      });
+      const data = await res.json();
+      if (data.error) {
+        statusEl.innerHTML = `<span style="font-size:10px;color:#f87171">${data.error}</span>`;
+      } else {
+        const color = data.sufficient ? '#22c55e' : '#f87171';
+        statusEl.innerHTML = `<span style="font-size:10px;color:${color}">${Number(data.balanceEth).toFixed(4)} ETH${data.sufficient ? ' ✓' : ' (insufficient)'}</span>`;
+      }
+    } catch {
+      statusEl.innerHTML = '<span style="font-size:10px;color:#f87171">Check failed</span>';
+    }
+  }
+}
+
+async function handleBundleDeploy() {
+  if (!bundleDeploymentId) return;
+  const btn = document.getElementById('bundle-deploy-btn');
+  const errorEl = document.getElementById('bundle-error');
+  if (errorEl) { errorEl.style.display = 'none'; errorEl.textContent = ''; }
+
+  // Build config update
+  const config = { mode: bundleMode, chainforgeBundle: true };
+
+  if (bundleMode === 'testnet') {
+    const rpcUrl = document.getElementById('bundle-testnet-rpc')?.value?.trim();
+    if (!rpcUrl) {
+      if (errorEl) { errorEl.textContent = 'L1 RPC URL is required for testnet deployment.'; errorEl.style.display = ''; }
+      return;
+    }
+    const deployerKey = document.getElementById('bundle-deployer-key')?.value;
+    if (!deployerKey) {
+      if (errorEl) { errorEl.textContent = 'Deployer key is required for testnet deployment.'; errorEl.style.display = ''; }
+      return;
+    }
+    config.l1RpcUrl = rpcUrl;
+    config.deployerKey = deployerKey;
+    config.committerKey = document.getElementById('bundle-committer-key')?.value || deployerKey;
+    config.proofCoordinatorKey = document.getElementById('bundle-proof-coordinator-key')?.value || deployerKey;
+    config.bridgeOwnerKey = document.getElementById('bundle-bridge-owner-key')?.value || deployerKey;
+  }
+
+  // Merge existing config (preserve bundlePrograms etc.)
+  try {
+    const depRes = await fetch(`${API}/deployments/${bundleDeploymentId}`);
+    const dep = await depRes.json();
+    if (dep?.deployment?.config) {
+      const existing = typeof dep.deployment.config === 'string' ? JSON.parse(dep.deployment.config) : dep.deployment.config;
+      config.bundlePrograms = existing.bundlePrograms;
+      config.bundleContracts = existing.bundleContracts;
+    }
+  } catch (e) { console.warn('[bundle] merge config:', e.message); }
+
+  if (btn) { btn.disabled = true; btn.textContent = 'Deploying...'; }
+
+  try {
+    // Update deployment config
+    const updateRes = await fetch(`${API}/deployments/${bundleDeploymentId}`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ config }),
+    });
+    if (!updateRes.ok) {
+      const err = await updateRes.json();
+      throw new Error(err.error || 'Failed to update deployment config');
+    }
+
+    // Start provisioning
+    const provRes = await fetch(`${API}/deployments/${bundleDeploymentId}/provision`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({}),
+    });
+    if (!provRes.ok) {
+      const err = await provRes.json();
+      throw new Error(err.error || 'Failed to start provisioning');
+    }
+
+    // Switch to Step 3 (deploy progress) — reuse existing progress UI
+    showView('launch');
+    document.getElementById('launch-step1').style.display = 'none';
+    document.getElementById('launch-step2').style.display = 'none';
+    document.getElementById('launch-step3').style.display = '';
+    launchDeploymentId = bundleDeploymentId;
+    startDeployProgress(bundleDeploymentId);
+  } catch (err) {
+    if (errorEl) { errorEl.textContent = err.message; errorEl.style.display = ''; }
+  } finally {
+    if (btn) { btn.disabled = false; btn.textContent = 'Deploy Chain'; }
+  }
+}
+
 const initialView = urlParams.get('view');
 const detailId = urlParams.get('detail');
 loadDeployments().then(() => {
-  if (detailId) {
+  if (detailId && initialView === 'bundle-deploy') {
+    showBundleDeploy(detailId);
+  } else if (detailId) {
     showDeploymentDetail(detailId);
   } else if (editId) {
     editConfiguredDeploy(editId);

--- a/crates/desktop-app/local-server/public/index.html
+++ b/crates/desktop-app/local-server/public/index.html
@@ -496,6 +496,111 @@
         </div>
       </section>
 
+      <!-- Bundle Deploy (ChainForge) -->
+      <section id="view-bundle-deploy" class="view">
+        <div class="detail-header">
+          <div class="back-link">
+            <button class="btn-back" onclick="showView('deployments')">
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="15 18 9 12 15 6"/></svg>
+              Back to My L2s
+            </button>
+          </div>
+          <h2 style="font-size:16px;margin-bottom:4px">Deploy ChainForge Bundle</h2>
+          <p class="step-desc" style="margin-bottom:14px">Configure and deploy a chain designed in ChainForge Studio.</p>
+        </div>
+
+        <div id="bundle-info-card" class="selected-program-card" style="padding:12px 16px;margin-bottom:14px">
+          <div style="font-size:13px;font-weight:700;margin-bottom:6px" id="bundle-chain-name">Loading...</div>
+          <div style="display:flex;gap:16px;font-size:11px;color:var(--text-secondary)">
+            <span>Programs: <strong id="bundle-program-count">-</strong></span>
+            <span>Chain ID: <strong id="bundle-chain-id">-</strong></span>
+          </div>
+          <div id="bundle-program-list" style="margin-top:8px;font-size:11px;color:var(--text-secondary)"></div>
+        </div>
+
+        <div class="config-form">
+          <label style="margin-bottom:8px">Environment</label>
+          <div class="mode-cards" style="margin-bottom:12px">
+            <button type="button" class="mode-card active" data-mode="local" onclick="setBundleMode('local')" style="padding:8px">
+              <div class="mode-title">Local (Docker)</div>
+              <div class="mode-desc">Build and run on this machine</div>
+            </button>
+            <button type="button" class="mode-card" data-mode="testnet" onclick="setBundleMode('testnet')" style="padding:8px">
+              <div class="mode-title">Testnet</div>
+              <div class="mode-desc">Deploy to Sepolia / Holesky / Custom L1</div>
+            </button>
+          </div>
+
+          <div id="bundle-testnet-fields" style="display:none">
+            <div class="testnet-info-box" style="background:var(--blue-50,#eff6ff);border:1px solid var(--blue-200,#bfdbfe);border-radius:8px;padding:10px 14px;margin-bottom:12px">
+              <p style="font-weight:600;color:var(--blue-700,#1d4ed8);margin-bottom:4px;font-size:13px">Testnet Deployment</p>
+              <p style="color:var(--blue-600,#2563eb);font-size:11px;line-height:1.5">
+                No built-in L1 node will be started. L2 contracts will be deployed to the external L1.<br>
+                The deployer account must be funded with testnet ETH.
+              </p>
+            </div>
+            <label style="margin-bottom:8px">L1 RPC URL *
+              <input type="text" id="bundle-testnet-rpc" placeholder="https://sepolia.infura.io/v3/YOUR_KEY" style="border-color:#f87171">
+              <p class="form-hint">Ethereum L1 RPC endpoint.</p>
+            </label>
+            <div style="display:flex;justify-content:space-between;align-items:center;margin-bottom:6px">
+              <p style="font-weight:600;font-size:13px;margin:0">Wallet Configuration</p>
+              <div style="display:flex;gap:6px;align-items:center">
+                <button type="button" class="btn-secondary" onclick="registerKeychainKey()" style="font-size:11px;white-space:nowrap;padding:4px 8px">+ Register Key</button>
+                <button type="button" class="btn-secondary" onclick="refreshBundleKeychainKeys()" style="font-size:11px;white-space:nowrap;padding:4px 8px" title="Refresh key list">↻</button>
+              </div>
+            </div>
+            <p class="form-hint" style="margin-bottom:8px">Private keys are stored in macOS Keychain. The app only references key names.</p>
+            <div style="display:grid;grid-template-columns:1fr 1fr;gap:10px;margin-bottom:10px">
+              <div style="border-left:4px solid #2563eb;border-radius:8px;padding:10px 10px 10px 12px;background:#eff6ff;box-shadow:0 1px 2px rgba(0,0,0,0.05)">
+                <div style="font-size:12px;font-weight:700;color:#1d4ed8;margin-bottom:4px">Deployer *</div>
+                <select id="bundle-deployer-key" onchange="onBundleKeychainKeyChange()" style="margin:0 0 2px;font-size:12px;width:100%">
+                  <option value="">Select key...</option>
+                </select>
+                <input type="text" id="bundle-deployer-addr" placeholder="—" readonly style="background:white;color:#4b5563;font-size:10px;padding:3px 6px;width:100%;box-sizing:border-box">
+                <div id="bundle-balance-deployer"></div>
+              </div>
+              <div style="border-left:4px solid #16a34a;border-radius:8px;padding:10px 10px 10px 12px;background:#f0fdf4;box-shadow:0 1px 2px rgba(0,0,0,0.05)">
+                <div style="font-size:12px;font-weight:700;color:#15803d;margin-bottom:4px">Committer</div>
+                <select id="bundle-committer-key" onchange="onBundleRoleKeyChange('committer')" style="margin:0 0 2px;font-size:12px;width:100%">
+                  <option value="">Same as Deployer</option>
+                </select>
+                <input type="text" id="bundle-committer-addr" placeholder="= Deployer" readonly style="background:white;color:#4b5563;font-size:10px;padding:3px 6px;width:100%;box-sizing:border-box">
+                <div id="bundle-balance-committer"></div>
+              </div>
+              <div style="border-left:4px solid #9333ea;border-radius:8px;padding:10px 10px 10px 12px;background:#faf5ff;box-shadow:0 1px 2px rgba(0,0,0,0.05)">
+                <div style="font-size:12px;font-weight:700;color:#7e22ce;margin-bottom:4px">Proof Coordinator</div>
+                <select id="bundle-proof-coordinator-key" onchange="onBundleRoleKeyChange('proof-coordinator')" style="margin:0 0 2px;font-size:12px;width:100%">
+                  <option value="">Same as Deployer</option>
+                </select>
+                <input type="text" id="bundle-proof-coordinator-addr" placeholder="= Deployer" readonly style="background:white;color:#4b5563;font-size:10px;padding:3px 6px;width:100%;box-sizing:border-box">
+                <div id="bundle-balance-proof-coordinator"></div>
+              </div>
+              <div style="border-left:4px solid #d97706;border-radius:8px;padding:10px 10px 10px 12px;background:#fffbeb;box-shadow:0 1px 2px rgba(0,0,0,0.05)">
+                <div style="font-size:12px;font-weight:700;color:#b45309;margin-bottom:4px">Bridge Owner</div>
+                <select id="bundle-bridge-owner-key" onchange="onBundleRoleKeyChange('bridge-owner')" style="margin:0 0 2px;font-size:12px;width:100%">
+                  <option value="">Same as Deployer</option>
+                </select>
+                <input type="text" id="bundle-bridge-owner-addr" placeholder="= Deployer" readonly style="background:white;color:#4b5563;font-size:10px;padding:3px 6px;width:100%;box-sizing:border-box">
+                <div id="bundle-balance-bridge-owner"></div>
+              </div>
+            </div>
+            <div style="display:flex;gap:6px;margin-bottom:8px">
+              <button type="button" class="btn-secondary" onclick="checkBundleTestnetBalance()" style="font-size:11px">Check All Balances</button>
+            </div>
+            <div id="bundle-balance-check" style="margin-bottom:8px"></div>
+          </div>
+
+          <div id="bundle-docker-status"></div>
+          <div id="bundle-error" class="error-msg" style="display:none"></div>
+
+          <div class="form-actions" style="margin-top:12px">
+            <button class="btn-secondary" onclick="showView('deployments')">Cancel</button>
+            <button class="btn-primary" id="bundle-deploy-btn" onclick="handleBundleDeploy()">Deploy Chain</button>
+          </div>
+        </div>
+      </section>
+
       <!-- Deployment Detail -->
       <section id="view-detail" class="view">
         <div class="detail-header">

--- a/crates/desktop-app/local-server/routes/deployments.js
+++ b/crates/desktop-app/local-server/routes/deployments.js
@@ -398,6 +398,67 @@ router.post("/", (req, res) => {
   }
 });
 
+// POST /api/deployments/from-bundle — create deployment from ChainForge bundle
+router.post("/from-bundle", async (req, res) => {
+  try {
+    const { name, chainId, genesis, programsToml, programs, contracts, programSlug } = req.body;
+    if (!name) {
+      return res.status(400).json({ error: "name is required" });
+    }
+    if (!genesis) {
+      return res.status(400).json({ error: "genesis is required" });
+    }
+    if (!programsToml) {
+      return res.status(400).json({ error: "programsToml is required" });
+    }
+
+    // Validate genesis is valid JSON
+    try {
+      const parsed = typeof genesis === "string" ? JSON.parse(genesis) : genesis;
+      if (!parsed || typeof parsed !== "object") throw new Error("not an object");
+    } catch (e) {
+      return res.status(400).json({ error: `Invalid genesis JSON: ${e.message}` });
+    }
+
+    // Validate programsToml is non-empty string
+    if (typeof programsToml !== "string" || !programsToml.trim()) {
+      return res.status(400).json({ error: "programsToml must be a non-empty string" });
+    }
+
+    // Determine program slug from bundle or default to evm-l2
+    const slug = programSlug && /^[a-z0-9_-]{1,64}$/.test(programSlug) ? programSlug : "evm-l2";
+
+    const id = uuidv4();
+    const now = Date.now();
+
+    // Store chainforgeBundle flag + programs metadata in config
+    const config = JSON.stringify({
+      chainforgeBundle: true,
+      bundlePrograms: programs || [],
+      bundleContracts: contracts || {},
+    });
+
+    db.prepare(`
+      INSERT INTO deployments (id, program_slug, stack_type, name, chain_id, config, created_at)
+      VALUES (?, ?, ?, ?, ?, ?, ?)
+    `).run(id, slug, "ethrex", name.trim(), chainId || null, config, now);
+
+    // Write genesis.json and programs.toml to deployment dir
+    const deployDir = getDeploymentDir(id);
+    fs.mkdirSync(deployDir, { recursive: true });
+
+    const genesisContent = typeof genesis === 'string' ? genesis : JSON.stringify(genesis, null, 2);
+    fs.writeFileSync(path.join(deployDir, "l2.json"), genesisContent, "utf-8");
+    fs.writeFileSync(path.join(deployDir, "programs.toml"), programsToml, "utf-8");
+
+    const deployment = db.prepare("SELECT * FROM deployments WHERE id = ?").get(id);
+    const configUrl = `/index.html?view=bundle-deploy&detail=${id}`;
+    res.status(201).json({ deployment, configUrl });
+  } catch (e) {
+    res.status(500).json({ error: e.message });
+  }
+});
+
 // GET /api/deployments — list all local deployments
 router.get("/", (req, res) => {
   try {

--- a/crates/desktop-app/local-server/server.js
+++ b/crates/desktop-app/local-server/server.js
@@ -32,7 +32,7 @@ app.use(cors({
   },
   credentials: true,
 }));
-app.use(express.json());
+app.use(express.json({ limit: '5mb' }));
 
 // Static web UI (no cache during development)
 app.use(express.static(path.join(__dirname, "public"), {

--- a/crates/desktop-app/local-server/test.js
+++ b/crates/desktop-app/local-server/test.js
@@ -1864,6 +1864,212 @@ testAsync("isHealthy returns false for unreachable host", async () => {
       return Promise.resolve();
     })
 
+    // ============================================================
+    // ChainForge Bundle Deploy Tests
+    // ============================================================
+    .then(async () => {
+      console.log("\n=== ChainForge Bundle Deploy Tests ===");
+
+      const app = require("./server");
+      const server = http.createServer(app);
+      await new Promise((resolve) => server.listen(0, resolve));
+      const port = server.address().port;
+      const base = `http://127.0.0.1:${port}`;
+
+      try {
+        // -- POST /from-bundle creates deployment with files --
+        let bundleDeployId;
+        const testGenesis = JSON.stringify({
+          config: { chainId: 901, homesteadBlock: 0, eip150Block: 0 },
+          alloc: { "0xFFFF": { balance: "0x0", code: "0x00" } },
+          gasLimit: "0x1c9c380",
+          nonce: "0x42",
+        });
+        const testProgramsToml = [
+          'default_program = "evm-l2"',
+          'enabled_programs = ["evm-l2", "bridge"]',
+          "",
+          "[programs.evm-l2]",
+          "type_id = 1",
+          'display_name = "EVM L2"',
+          "is_base = true",
+          "",
+          "[programs.bridge]",
+          "type_id = 2",
+          'display_name = "Bridge"',
+          "is_base = false",
+        ].join("\n");
+        const testPrograms = [
+          { programId: "evm-l2", programTypeId: 1, role: "base" },
+          { programId: "bridge", programTypeId: 2, role: "app-specific" },
+        ];
+
+        await testAsync("POST /from-bundle creates deployment", async () => {
+          const res = await fetch(`${base}/api/deployments/from-bundle`, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+              name: "Bundle Test Chain",
+              chainId: 65537001,
+              genesis: testGenesis,
+              programsToml: testProgramsToml,
+              programs: testPrograms,
+              contracts: { l1: { OnChainProposer: "<pending>" }, l2System: {} },
+            }),
+          });
+          assert.equal(res.status, 201, `Expected 201, got ${res.status}`);
+          const data = await res.json();
+          assert.ok(data.deployment, "response should have deployment");
+          assert.ok(data.deployment.id, "deployment should have id");
+          assert.equal(data.deployment.name, "Bundle Test Chain");
+          assert.ok(data.configUrl, "response should have configUrl");
+          assert.ok(data.configUrl.includes("bundle-deploy"), "configUrl should reference bundle-deploy view");
+          bundleDeployId = data.deployment.id;
+        });
+
+        await testAsync("POST /from-bundle writes genesis l2.json to deploy dir", async () => {
+          const { getDeploymentDir } = require("./lib/compose-generator");
+          const deployDir = getDeploymentDir(bundleDeployId);
+          const genesisPath = path.join(deployDir, "l2.json");
+          assert.ok(fs.existsSync(genesisPath), "l2.json should exist in deploy dir");
+          const content = JSON.parse(fs.readFileSync(genesisPath, "utf-8"));
+          assert.equal(content.config.chainId, 901, "genesis chainId should match");
+          assert.ok(content.alloc["0xFFFF"], "genesis alloc should be preserved");
+        });
+
+        await testAsync("POST /from-bundle writes programs.toml to deploy dir", async () => {
+          const { getDeploymentDir } = require("./lib/compose-generator");
+          const deployDir = getDeploymentDir(bundleDeployId);
+          const tomlPath = path.join(deployDir, "programs.toml");
+          assert.ok(fs.existsSync(tomlPath), "programs.toml should exist in deploy dir");
+          const content = fs.readFileSync(tomlPath, "utf-8");
+          assert.ok(content.includes('default_program = "evm-l2"'), "programs.toml should have default_program");
+          assert.ok(content.includes("[programs.bridge]"), "programs.toml should have bridge section");
+        });
+
+        await testAsync("POST /from-bundle stores chainforgeBundle flag in config", async () => {
+          const dep = db.prepare("SELECT * FROM deployments WHERE id = ?").get(bundleDeployId);
+          assert.ok(dep, "deployment should exist in DB");
+          const config = JSON.parse(dep.config);
+          assert.equal(config.chainforgeBundle, true, "config should have chainforgeBundle: true");
+          assert.ok(Array.isArray(config.bundlePrograms), "config should have bundlePrograms array");
+          assert.equal(config.bundlePrograms.length, 2, "should have 2 programs");
+          assert.equal(config.bundlePrograms[0].programId, "evm-l2");
+        });
+
+        await testAsync("POST /from-bundle rejects missing name", async () => {
+          const res = await fetch(`${base}/api/deployments/from-bundle`, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ genesis: "{}", programsToml: "x" }),
+          });
+          assert.equal(res.status, 400);
+          const data = await res.json();
+          assert.ok(data.error.includes("name"), "error should mention name");
+        });
+
+        await testAsync("POST /from-bundle rejects missing genesis", async () => {
+          const res = await fetch(`${base}/api/deployments/from-bundle`, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ name: "Test", programsToml: "x" }),
+          });
+          assert.equal(res.status, 400);
+          const data = await res.json();
+          assert.ok(data.error.includes("genesis"), "error should mention genesis");
+        });
+
+        await testAsync("POST /from-bundle rejects missing programsToml", async () => {
+          const res = await fetch(`${base}/api/deployments/from-bundle`, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ name: "Test", genesis: "{}" }),
+          });
+          assert.equal(res.status, 400);
+          const data = await res.json();
+          assert.ok(data.error.includes("programsToml"), "error should mention programsToml");
+        });
+
+        await testAsync("GET /deployments/:id returns bundle deployment", async () => {
+          const res = await fetch(`${base}/api/deployments/${bundleDeployId}`);
+          assert.equal(res.status, 200);
+          const data = await res.json();
+          assert.equal(data.deployment.name, "Bundle Test Chain");
+          assert.equal(data.deployment.chain_id, 65537001);
+          assert.equal(data.deployment.program_slug, "evm-l2");
+          assert.equal(data.deployment.stack_type, "ethrex");
+        });
+
+        // -- Compose generator: bundleProgramsToml --
+        await testAsync("compose-generator uses bundleProgramsToml when provided", async () => {
+          const { generateComposeFile } = require("./lib/compose-generator");
+          const compose = generateComposeFile({
+            programSlug: "evm-l2",
+            l1Port: 8545,
+            l2Port: 1729,
+            proofCoordPort: 3900,
+            metricsPort: 3702,
+            projectName: "test-bundle",
+            customGenesisPath: "/tmp/test-genesis.json",
+            l2ChainId: 65537001,
+            customL1GenesisPath: "/tmp/test-l1.json",
+            bundleProgramsToml: "/tmp/test-programs.toml",
+          });
+          assert.ok(compose.includes("/tmp/test-programs.toml:/etc/ethrex/programs.toml"), "compose should mount bundle programs.toml");
+          assert.ok(compose.includes("--programs-config /etc/ethrex/programs.toml"), "compose should include programs-config flag");
+        });
+
+        await testAsync("compose-generator testnet uses bundleProgramsToml", async () => {
+          const { generateTestnetComposeFile } = require("./lib/compose-generator");
+          const compose = generateTestnetComposeFile({
+            programSlug: "evm-l2",
+            l2Port: 1729,
+            proofCoordPort: 3900,
+            metricsPort: 3702,
+            projectName: "test-bundle-tn",
+            l1RpcUrl: "https://sepolia.example.com",
+            deployerAddress: "0x1111111111111111111111111111111111111111",
+            committerAddress: "0x2222222222222222222222222222222222222222",
+            proofCoordinatorAddress: "0x3333333333333333333333333333333333333333",
+            bridgeOwnerAddress: "0x4444444444444444444444444444444444444444",
+            customGenesisPath: "/tmp/test-genesis.json",
+            l2ChainId: 65537001,
+            bundleProgramsToml: "/tmp/test-programs.toml",
+          });
+          assert.ok(compose.includes("/tmp/test-programs.toml:/etc/ethrex/programs.toml"), "testnet compose should mount bundle programs.toml");
+        });
+
+        await testAsync("compose-generator without bundleProgramsToml uses stock path", async () => {
+          const { generateComposeFile } = require("./lib/compose-generator");
+          const compose = generateComposeFile({
+            programSlug: "evm-l2",
+            l1Port: 8545,
+            l2Port: 1729,
+            proofCoordPort: 3900,
+            metricsPort: 3702,
+            projectName: "test-stock",
+            customGenesisPath: "/tmp/test-genesis.json",
+            l2ChainId: 901,
+            customL1GenesisPath: "/tmp/test-l1.json",
+          });
+          // evm-l2 profile has no programsToml, so no mount should appear
+          assert.ok(!compose.includes("/etc/ethrex/programs.toml"), "stock evm-l2 should not mount programs.toml");
+        });
+
+        // Cleanup bundle deployment
+        db.prepare("DELETE FROM deployments WHERE id = ?").run(bundleDeployId);
+        const { getDeploymentDir } = require("./lib/compose-generator");
+        const bundleDir = getDeploymentDir(bundleDeployId);
+        if (fs.existsSync(bundleDir)) {
+          fs.rmSync(bundleDir, { recursive: true, force: true });
+        }
+      } finally {
+        server.close();
+      }
+
+      return Promise.resolve();
+    })
+
     .then(() => {
       // Cleanup
       fs.rmSync(testDir, { recursive: true, force: true });


### PR DESCRIPTION
## Summary
- **New endpoint** `POST /api/deployments/from-bundle` receives complete chain bundles from ChainForge Studio (genesis, programs.toml, program metadata, contracts)
- **deployment-engine.js**: `ensureChainIds()` detects bundle genesis and skips stock genesis write; `provision()`/`provisionTestnet()` pass bundle programs.toml path to compose generators
- **compose-generator.js**: `generateComposeFile()`/`generateTestnetComposeFile()` mount bundle programs.toml for L2 and prover containers when provided
- **Bundle deploy UI**: new `view-bundle-deploy` section with environment selector (Local/Testnet), wallet config for testnet, and deploy button that reuses existing progress tracking
- **server.js**: JSON body limit raised to 5mb for large genesis payloads
- Companion PR (ChainForge Studio): tokamak-network/chainforge-studio#11

## Test plan
- [x] API tests: from-bundle endpoint creation, file writes, validation (7 tests)
- [x] Compose generator tests: bundleProgramsToml mount for local + testnet (3 tests)
- [x] GET /:id verification for bundle deployments (1 test)
- [x] Full suite: **129 passed, 0 failed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)